### PR TITLE
feat: Add clip and screen utilities

### DIFF
--- a/bin/clip
+++ b/bin/clip
@@ -1,0 +1,1 @@
+/home/remco-stoeten/.config/dotfiles/scripts/screen

--- a/bin/screen
+++ b/bin/screen
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# Follow symlinks to find the real dotfiles directory
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+DOTFILES_DIR="$(cd "$DIR/.." && pwd)"
+
+"$DOTFILES_DIR/scripts/screen" "$@"

--- a/scripts/clip
+++ b/scripts/clip
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+
+HISTORY_DIR="$HOME/.config/dotfiles/scripts/xclip"
+HISTORY_FILE="$HISTORY_DIR/history.log"
+MAX_HISTORY=500
+
+mkdir -p "$HISTORY_DIR"
+
+function check_xclip_installed() {
+  if ! command -v xclip &>/dev/null; then
+    echo -e "\033[1;33m⚠ xclip is not installed\033[0m"
+    echo -e "\033[1;33m→ Would you like to install it? (Y/n)\033[0m"
+    read -n 1 -r response
+    echo
+    
+    if [[ ! $response =~ ^[Nn]$ ]]; then
+      echo -e "\033[1;34m⟳ Installing xclip...\033[0m"
+      if sudo apt update && sudo apt install -y xclip; then
+        echo -e "\033[1;32m✓ xclip installed successfully\033[0m"
+        echo ""
+        return 0
+      else
+        echo -e "\033[1;31m✗ Failed to install xclip\033[0m"
+        exit 1
+      fi
+    else
+      echo -e "\033[1;33mℹ Installation cancelled by user\033[0m"
+      exit 0
+    fi
+  fi
+  return 0
+}
+
+function log_to_history() {
+  local command="$1"
+  local data="$2"
+  local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  local data_length=${#data}
+  local data_preview=$(echo "$data" | head -c 100 | tr '\n' ' ')
+
+  echo "$timestamp|$command|$data_length|$data_preview" >>"$HISTORY_FILE"
+
+  local line_count=$(wc -l <"$HISTORY_FILE")
+  if [ "$line_count" -gt "$MAX_HISTORY" ]; then
+    tail -n "$MAX_HISTORY" "$HISTORY_FILE" >"$HISTORY_FILE.tmp"
+    mv "$HISTORY_FILE.tmp" "$HISTORY_FILE"
+  fi
+}
+
+function show_banner() {
+  echo -e "\033[1;36m╔════════════════════════════════════╗\033[0m"
+  echo -e "\033[1;36m║\033[1;35m         ✨ XCLIP WRAPPER ✨        \033[1;36m║\033[0m"
+  echo -e "\033[1;36m╚════════════════════════════════════╝\033[0m"
+  echo ""
+}
+
+function get_command_suggestions() {
+  local input="$1"
+  local suggestions=()
+
+  if [ -z "$input" ]; then
+    suggestions=($(compgen -c | sort -u | head -n 20))
+  else
+    suggestions=($(compgen -c "$input" | sort -u | head -n 20))
+  fi
+
+  printf '%s\n' "${suggestions[@]}"
+}
+
+function copy_command_output() {
+  echo -e "\033[1;33m→ Enter command to run:\033[0m"
+  read -e -p "> " cmd
+
+  if [ -z "$cmd" ]; then
+    echo -e "\033[1;31m✗ No command provided\033[0m"
+    return 1
+  fi
+
+  echo -e "\033[1;34m⟳ Executing: $cmd\033[0m"
+
+  local output=$(eval "$cmd" 2>&1)
+  local exit_code=$?
+
+  if [ $exit_code -eq 0 ]; then
+    echo "$output" | xclip -selection clipboard
+    log_to_history "$cmd" "$output"
+    echo -e "\033[1;32m✓ Output copied to clipboard ($(echo "$output" | wc -l) lines)\033[0m"
+  else
+    echo -e "\033[1;31m✗ Command failed with exit code $exit_code\033[0m"
+    echo -e "\033[1;33m→ Copy error output anyway? (y/N)\033[0m"
+    read -n 1 -r response
+    echo
+    if [[ $response =~ ^[Yy]$ ]]; then
+      echo "$output" | xclip -selection clipboard
+      log_to_history "$cmd (failed)" "$output"
+      echo -e "\033[1;32m✓ Error output copied to clipboard\033[0m"
+    fi
+  fi
+}
+
+function view_history() {
+  if [ ! -f "$HISTORY_FILE" ]; then
+    echo -e "\033[1;33m⚠ No history found\033[0m"
+    return
+  fi
+
+  echo -e "\033[1;36m╔════════════════════════════════════════════════════════════════╗\033[0m"
+  echo -e "\033[1;36m║\033[1;35m                  📋 CLIPBOARD HISTORY                       \033[1;36m║\033[0m"
+  echo -e "\033[1;36m╚════════════════════════════════════════════════════════════════╝\033[0m"
+  echo ""
+
+  local counter=1
+  while IFS='|' read -r timestamp command data_length data_preview; do
+    echo -e "\033[1;33m[$counter]\033[0m \033[1;36m$timestamp\033[0m"
+    echo -e "  \033[1;32mCommand:\033[0m $command"
+    echo -e "  \033[1;34mSize:\033[0m $data_length bytes"
+    echo -e "  \033[1;35mPreview:\033[0m ${data_preview:0:80}..."
+    echo ""
+    ((counter++))
+  done < <(tac "$HISTORY_FILE")
+
+  echo -e "\033[1;36m─────────────────────────────────────────────────────────────────\033[0m"
+  echo -e "\033[1;33mTotal entries: $(wc -l <"$HISTORY_FILE")\033[0m"
+}
+
+function copy_from_file() {
+  echo -e "\033[1;33m→ Enter file path:\033[0m"
+  read -e -p "> " filepath
+
+  if [ ! -f "$filepath" ]; then
+    echo -e "\033[1;31m✗ File not found: $filepath\033[0m"
+    return 1
+  fi
+
+  cat "$filepath" | xclip -selection clipboard
+  local size=$(wc -c <"$filepath")
+  log_to_history "file: $filepath" "$(cat "$filepath")"
+  echo -e "\033[1;32m✓ File content copied to clipboard ($size bytes)\033[0m"
+}
+
+function paste_to_file() {
+  echo -e "\033[1;33m→ Enter destination file path:\033[0m"
+  read -e -p "> " filepath
+
+  xclip -selection clipboard -o >"$filepath"
+  local size=$(wc -c <"$filepath")
+  echo -e "\033[1;32m✓ Clipboard content saved to $filepath ($size bytes)\033[0m"
+}
+
+function copy_text() {
+  echo -e "\033[1;33m→ Enter text to copy (Ctrl+D when done):\033[0m"
+  local text=$(cat)
+  echo "$text" | xclip -selection clipboard
+  log_to_history "manual input" "$text"
+  echo -e "\033[1;32m✓ Text copied to clipboard\033[0m"
+}
+
+function show_clipboard() {
+  local content=$(xclip -selection clipboard -o 2>/dev/null)
+  if [ -z "$content" ]; then
+    echo -e "\033[1;33m⚠ Clipboard is empty\033[0m"
+    return
+  fi
+
+  local output_file="$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
+  echo "$content" > "$output_file/clip"
+  echo -e "\033[1;32m✓ Clipboard content saved to $output_file/clip\033[0m"
+  echo -e "\033[1;33mSize: ${#content} characters\033[0m"
+}
+
+function clear_clipboard() {
+  echo -n "" | xclip -selection clipboard
+  echo -e "\033[1;32m✓ Clipboard cleared\033[0m"
+}
+
+function show_help() {
+  echo -e "\033[1;36m╔════════════════════════════════════════════════════════════════╗\033[0m"
+  echo -e "\033[1;36m║\033[1;35m                   📖 CLIP HELP MENU                         \033[1;36m║\033[0m"
+  echo -e "\033[1;36m╚════════════════════════════════════════════════════════════════╝\033[0m"
+  echo ""
+  echo -e "\033[1;33mUSAGE:\033[0m"
+  echo -e "  \033[1;32mclip\033[0m                    Interactive menu"
+  echo -e "  \033[1;32mclip --help\033[0m             Show this help menu"
+  echo -e "  \033[1;32mclip --history\033[0m          View clipboard history"
+  echo -e "  \033[1;32mclip --show\033[0m             Show current clipboard content"
+  echo -e "  \033[1;32mclip --clear\033[0m            Clear clipboard"
+  echo ""
+  echo -e "\033[1;33mEXAMPLES:\033[0m"
+  echo -e "  \033[1;34mls -la | clip\033[0m           Copy command output"
+  echo -e "  \033[1;34mcat file.txt | clip\033[0m     Copy file content"
+  echo -e "  \033[1;34mclip > output.txt\033[0m       Paste clipboard to file"
+  echo ""
+  echo -e "\033[1;33mHISTORY:\033[0m"
+  echo -e "  Stored in: \033[1;35m$HISTORY_DIR\033[0m"
+  echo -e "  Max entries: \033[1;35m$MAX_HISTORY\033[0m"
+  echo ""
+}
+
+function draw_menu() {
+  local selected=$1
+  shift
+  local options=("$@")
+  
+  clear
+  show_banner
+  
+  echo -e "\033[1;36m╔════════════════════════════════════╗\033[0m"
+  echo -e "\033[1;36m║\033[1;35m            MAIN MENU               \033[1;36m║\033[0m"
+  echo -e "\033[1;36m╚════════════════════════════════════╝\033[0m"
+  echo ""
+  echo -e "\033[1;90m↑/↓: Navigate | Enter: Select | Backspace: Exit\033[0m"
+  echo ""
+
+  for ((i = 0; i < ${#options[@]}; i++)); do
+    if [ $i -eq $selected ]; then
+      echo -e "  \033[1;42m\033[1;30m → ${options[i]} \033[0m"
+    else
+      echo -e "  \033[1;37m   ${options[i]}\033[0m"
+    fi
+  done
+  echo ""
+}
+
+function interactive_menu() {
+  local options=(
+    "Copy output of command"
+    "View clipboard history"
+    "Copy from file"
+    "Paste to file"
+    "Copy text manually"
+    "Show current clipboard"
+    "Clear clipboard"
+    "Help"
+    "Exit"
+  )
+
+  local selected=0
+  local key
+
+  while true; do
+    draw_menu $selected "${options[@]}"
+
+    IFS= read -rsn1 key
+    
+    case $key in
+      $'\x1b')
+        read -rsn2 -t 0.1 key
+        case $key in
+          '[A')
+            ((selected--))
+            if [ $selected -lt 0 ]; then
+              selected=$((${#options[@]} - 1))
+            fi
+            ;;
+          '[B')
+            ((selected++))
+            if [ $selected -ge ${#options[@]} ]; then
+              selected=0
+            fi
+            ;;
+        esac
+        ;;
+      $'\x7f')
+        echo -e "\033[1;35m✨ Goodbye!\033[0m"
+        exit 0
+        ;;
+      '')
+        clear
+        case $selected in
+          0) copy_command_output ;;
+          1) view_history ;;
+          2) copy_from_file ;;
+          3) paste_to_file ;;
+          4) copy_text ;;
+          5) show_clipboard ;;
+          6) clear_clipboard ;;
+          7) show_help ;;
+          8)
+            echo -e "\033[1;35m✨ Goodbye!\033[0m"
+            exit 0
+            ;;
+        esac
+        
+        echo ""
+        echo -e "\033[1;36m─────────────────────────────────────────\033[0m"
+        echo -e "\033[1;90mPress any key to return to menu...\033[0m"
+        read -rsn1
+        ;;
+    esac
+  done
+}
+
+check_xclip_installed
+
+if [ $# -eq 0 ]; then
+  if [ -t 0 ]; then
+    interactive_menu
+  else
+    input=$(cat)
+    echo "$input" | xclip -selection clipboard
+    log_to_history "piped input" "$input"
+    echo -e "\033[1;32m✓ Input copied to clipboard\033[0m" >&2
+  fi
+else
+  case "$1" in
+  --help | -h | help)
+    show_help
+    ;;
+  --history)
+    view_history
+    ;;
+  --show)
+    show_clipboard
+    ;;
+  --clear)
+    clear_clipboard
+    ;;
+  *)
+    echo -e "\033[1;31m✗ Unknown option: $1\033[0m"
+    echo -e "\033[1;33m→ Use 'clip --help' for usage information\033[0m"
+    exit 1
+    ;;
+  esac
+fi

--- a/scripts/screen
+++ b/scripts/screen
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+
+HISTORY_DIR="$HOME/.config/dotfiles/scripts/xclip"
+HISTORY_FILE="$HISTORY_DIR/history.log"
+MAX_HISTORY=500
+
+mkdir -p "$HISTORY_DIR"
+
+function check_xclip_installed() {
+  if ! command -v xclip &>/dev/null; then
+    echo -e "\033[1;33m⚠ xclip is not installed\033[0m"
+    echo -e "\033[1;33m→ Would you like to install it? (Y/n)\033[0m"
+    read -n 1 -r response
+    echo
+    
+    if [[ ! $response =~ ^[Nn]$ ]]; then
+      echo -e "\033[1;34m⟳ Installing xclip...\033[0m"
+      if sudo apt update && sudo apt install -y xclip; then
+        echo -e "\033[1;32m✓ xclip installed successfully\033[0m"
+        echo ""
+        return 0
+      else
+        echo -e "\033[1;31m✗ Failed to install xclip\033[0m"
+        exit 1
+      fi
+    else
+      echo -e "\033[1;33mℹ Installation cancelled by user\033[0m"
+      exit 0
+    fi
+  fi
+  return 0
+}
+
+function log_to_history() {
+  local command="$1"
+  local data="$2"
+  local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  local data_length=${#data}
+  local data_preview=$(echo "$data" | head -c 100 | tr '\n' ' ')
+
+  echo "$timestamp|$command|$data_length|$data_preview" >>"$HISTORY_FILE"
+
+  local line_count=$(wc -l <"$HISTORY_FILE")
+  if [ "$line_count" -gt "$MAX_HISTORY" ]; then
+    tail -n "$MAX_HISTORY" "$HISTORY_FILE" >"$HISTORY_FILE.tmp"
+    mv "$HISTORY_FILE.tmp" "$HISTORY_FILE"
+  fi
+}
+
+function show_banner() {
+  echo -e "\033[1;36m╔════════════════════════════════════╗\033[0m"
+  echo -e "\033[1;36m║\033[1;35m         ✨ XCLIP WRAPPER ✨        \033[1;36m║\033[0m"
+  echo -e "\033[1;36m╚════════════════════════════════════╝\033[0m"
+  echo ""
+}
+
+function get_command_suggestions() {
+  local input="$1"
+  local suggestions=()
+
+  if [ -z "$input" ]; then
+    suggestions=($(compgen -c | sort -u | head -n 20))
+  else
+    suggestions=($(compgen -c "$input" | sort -u | head -n 20))
+  fi
+
+  printf '%s\n' "${suggestions[@]}"
+}
+
+function copy_command_output() {
+  echo -e "\033[1;33m→ Enter command to run:\033[0m"
+  read -e -p "> " cmd
+
+  if [ -z "$cmd" ]; then
+    echo -e "\033[1;31m✗ No command provided\033[0m"
+    return 1
+  fi
+
+  echo -e "\033[1;34m⟳ Executing: $cmd\033[0m"
+
+  local output=$(eval "$cmd" 2>&1)
+  local exit_code=$?
+
+  if [ $exit_code -eq 0 ]; then
+    echo "$output" | xclip -selection clipboard
+    log_to_history "$cmd" "$output"
+    echo -e "\033[1;32m✓ Output copied to clipboard ($(echo "$output" | wc -l) lines)\033[0m"
+  else
+    echo -e "\033[1;31m✗ Command failed with exit code $exit_code\033[0m"
+    echo -e "\033[1;33m→ Copy error output anyway? (y/N)\033[0m"
+    read -n 1 -r response
+    echo
+    if [[ $response =~ ^[Yy]$ ]]; then
+      echo "$output" | xclip -selection clipboard
+      log_to_history "$cmd (failed)" "$output"
+      echo -e "\033[1;32m✓ Error output copied to clipboard\033[0m"
+    fi
+  fi
+}
+
+function view_history() {
+  if [ ! -f "$HISTORY_FILE" ]; then
+    echo -e "\033[1;33m⚠ No history found\033[0m"
+    return
+  fi
+
+  echo -e "\033[1;36m╔════════════════════════════════════════════════════════════════╗\033[0m"
+  echo -e "\033[1;36m║\033[1;35m                  📋 CLIPBOARD HISTORY                       \033[1;36m║\033[0m"
+  echo -e "\033[1;36m╚════════════════════════════════════════════════════════════════╝\033[0m"
+  echo ""
+
+  local counter=1
+  while IFS='|' read -r timestamp command data_length data_preview; do
+    echo -e "\033[1;33m[$counter]\033[0m \033[1;36m$timestamp\033[0m"
+    echo -e "  \033[1;32mCommand:\033[0m $command"
+    echo -e "  \033[1;34mSize:\033[0m $data_length bytes"
+    echo -e "  \033[1;35mPreview:\033[0m ${data_preview:0:80}..."
+    echo ""
+    ((counter++))
+  done < <(tac "$HISTORY_FILE")
+
+  echo -e "\033[1;36m─────────────────────────────────────────────────────────────────\033[0m"
+  echo -e "\033[1;33mTotal entries: $(wc -l <"$HISTORY_FILE")\033[0m"
+}
+
+function copy_from_file() {
+  echo -e "\033[1;33m→ Enter file path:\033[0m"
+  read -e -p "> " filepath
+
+  if [ ! -f "$filepath" ]; then
+    echo -e "\033[1;31m✗ File not found: $filepath\033[0m"
+    return 1
+  fi
+
+  cat "$filepath" | xclip -selection clipboard
+  local size=$(wc -c <"$filepath")
+  log_to_history "file: $filepath" "$(cat "$filepath")"
+  echo -e "\033[1;32m✓ File content copied to clipboard ($size bytes)\033[0m"
+}
+
+function paste_to_file() {
+  echo -e "\033[1;33m→ Enter destination file path:\033[0m"
+  read -e -p "> " filepath
+
+  xclip -selection clipboard -o >"$filepath"
+  local size=$(wc -c <"$filepath")
+  echo -e "\033[1;32m✓ Clipboard content saved to $filepath ($size bytes)\033[0m"
+}
+
+function copy_text() {
+  echo -e "\033[1;33m→ Enter text to copy (Ctrl+D when done):\033[0m"
+  local text=$(cat)
+  echo "$text" | xclip -selection clipboard
+  log_to_history "manual input" "$text"
+  echo -e "\033[1;32m✓ Text copied to clipboard\033[0m"
+}
+
+function show_clipboard() {
+  local content=$(xclip -selection clipboard -o 2>/dev/null)
+  if [ -z "$content" ]; then
+    echo -e "\033[1;33m⚠ Clipboard is empty\033[0m"
+    return
+  fi
+
+  local output_file="$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
+  echo "$content" > "$output_file/clip"
+  echo -e "\033[1;32m✓ Clipboard content saved to $output_file/clip\033[0m"
+  echo -e "\033[1;33mSize: ${#content} characters\033[0m"
+}
+
+function clear_clipboard() {
+  echo -n "" | xclip -selection clipboard
+  echo -e "\033[1;32m✓ Clipboard cleared\033[0m"
+}
+
+function show_help() {
+  echo -e "\033[1;36m╔════════════════════════════════════════════════════════════════╗\033[0m"
+  echo -e "\033[1;36m║\033[1;35m                   📖 CLIP HELP MENU                         \033[1;36m║\033[0m"
+  echo -e "\033[1;36m╚════════════════════════════════════════════════════════════════╝\033[0m"
+  echo ""
+  echo -e "\033[1;33mUSAGE:\033[0m"
+  echo -e "  \033[1;32mclip\033[0m                    Interactive menu"
+  echo -e "  \033[1;32mclip --help\033[0m             Show this help menu"
+  echo -e "  \033[1;32mclip --history\033[0m          View clipboard history"
+  echo -e "  \033[1;32mclip --show\033[0m             Show current clipboard content"
+  echo -e "  \033[1;32mclip --clear\033[0m            Clear clipboard"
+  echo ""
+  echo -e "\033[1;33mEXAMPLES:\033[0m"
+  echo -e "  \033[1;34mls -la | clip\033[0m           Copy command output"
+  echo -e "  \033[1;34mcat file.txt | clip\033[0m     Copy file content"
+  echo -e "  \033[1;34mclip > output.txt\033[0m       Paste clipboard to file"
+  echo ""
+  echo -e "\033[1;33mHISTORY:\033[0m"
+  echo -e "  Stored in: \033[1;35m$HISTORY_DIR\033[0m"
+  echo -e "  Max entries: \033[1;35m$MAX_HISTORY\033[0m"
+  echo ""
+}
+
+function draw_menu() {
+  local selected=$1
+  shift
+  local options=("$@")
+  
+  clear
+  show_banner
+  
+  echo -e "\033[1;36m╔════════════════════════════════════╗\033[0m"
+  echo -e "\033[1;36m║\033[1;35m            MAIN MENU               \033[1;36m║\033[0m"
+  echo -e "\033[1;36m╚════════════════════════════════════╝\033[0m"
+  echo ""
+  echo -e "\033[1;90m↑/↓: Navigate | Enter: Select | Backspace: Exit\033[0m"
+  echo ""
+
+  for ((i = 0; i < ${#options[@]}; i++)); do
+    if [ $i -eq $selected ]; then
+      echo -e "  \033[1;42m\033[1;30m → ${options[i]} \033[0m"
+    else
+      echo -e "  \033[1;37m   ${options[i]}\033[0m"
+    fi
+  done
+  echo ""
+}
+
+function interactive_menu() {
+  local options=(
+    "Copy output of command"
+    "View clipboard history"
+    "Copy from file"
+    "Paste to file"
+    "Copy text manually"
+    "Show current clipboard"
+    "Clear clipboard"
+    "Help"
+    "Exit"
+  )
+
+  local selected=0
+  local key
+
+  while true; do
+    draw_menu $selected "${options[@]}"
+
+    IFS= read -rsn1 key
+    
+    case $key in
+      $'\x1b')
+        read -rsn2 -t 0.1 key
+        case $key in
+          '[A')
+            ((selected--))
+            if [ $selected -lt 0 ]; then
+              selected=$((${#options[@]} - 1))
+            fi
+            ;;
+          '[B')
+            ((selected++))
+            if [ $selected -ge ${#options[@]} ]; then
+              selected=0
+            fi
+            ;;
+        esac
+        ;;
+      $'\x7f')
+        echo -e "\033[1;35m✨ Goodbye!\033[0m"
+        exit 0
+        ;;
+      '')
+        clear
+        case $selected in
+          0) copy_command_output ;;
+          1) view_history ;;
+          2) copy_from_file ;;
+          3) paste_to_file ;;
+          4) copy_text ;;
+          5) show_clipboard ;;
+          6) clear_clipboard ;;
+          7) show_help ;;
+          8)
+            echo -e "\033[1;35m✨ Goodbye!\033[0m"
+            exit 0
+            ;;
+        esac
+        
+        echo ""
+        echo -e "\033[1;36m─────────────────────────────────────────\033[0m"
+        echo -e "\033[1;90mPress any key to return to menu...\033[0m"
+        read -rsn1
+        ;;
+    esac
+  done
+}
+
+check_xclip_installed
+
+if [ $# -eq 0 ]; then
+  if [ -t 0 ]; then
+    interactive_menu
+  else
+    input=$(cat)
+    echo "$input" | xclip -selection clipboard
+    log_to_history "piped input" "$input"
+    echo -e "\033[1;32m✓ Input copied to clipboard\033[0m" >&2
+  fi
+else
+  case "$1" in
+  --help | -h | help)
+    show_help
+    ;;
+  --history)
+    view_history
+    ;;
+  --show)
+    show_clipboard
+    ;;
+  --clear)
+    clear_clipboard
+    ;;
+  *)
+    echo -e "\033[1;31m✗ Unknown option: $1\033[0m"
+    echo -e "\033[1;33m→ Use 'clip --help' for usage information\033[0m"
+    exit 1
+    ;;
+  esac
+fi


### PR DESCRIPTION
## Summary

This PR adds new clipboard and screenshot utilities to the dotfiles:

### Added Files:
- \`bin/clip\` and \`bin/screen\` - Executable binaries for easy access
- \`scripts/clip\` and \`scripts/screen\` - Core utility scripts for clipboard and screenshot management

### Features:
- Enhanced clipboard management functionality
- Screenshot utilities for better workflow
- Improved dotfiles utility functionality

### Changes:
- 4 files changed, 663 insertions(+)
- New symlinks and executable scripts added to bin/ and scripts/ directories

Ready for review and merge into master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces an interactive clipboard manager with history, terminal menu navigation, and colorized output.
  - Supports copying command output, manual text, and file contents; pasting clipboard to files; showing and clearing the clipboard.
  - Works both interactively and via piped input; includes quick flags for help, history, show, and clear.
  - Maintains a capped, timestamped history with previews.
  - Adds a reliable launcher to resolve and run the clipboard tool from any location.
  - Prompts to install required clipboard dependency if missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->