### PR TITLE
Add pacman support to installers and adapt Papirus install; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ cd ~/.config/dotfiles
 ./setup/setup.sh
 ```
 
+The setup script supports both `apt` (Debian/Ubuntu) and `pacman` (Arch-based) package managers.
+
 The installer can also be scoped:
 
 ```bash

--- a/setup/lib/installers.sh
+++ b/setup/lib/installers.sh
@@ -1,22 +1,94 @@
 #!/bin/bash
 set -euo pipefail
 
+detect_package_manager() {
+    if command -v apt >/dev/null 2>&1; then
+        echo "apt"
+        return 0
+    fi
+
+    if command -v pacman >/dev/null 2>&1; then
+        echo "pacman"
+        return 0
+    fi
+
+    echo "unknown"
+}
+
+map_pacman_package_name() {
+    local pkg="$1"
+
+    case "$pkg" in
+        build-essential) echo "base-devel" ;;
+        python3) echo "python" ;;
+        python3-pip) echo "python-pip" ;;
+        python3-venv) echo "__skip__" ;;
+        software-properties-common) echo "__skip__" ;;
+        fd-find) echo "fd" ;;
+        gh) echo "github-cli" ;;
+        docker.io) echo "docker" ;;
+        *) echo "$pkg" ;;
+    esac
+}
+
+is_installed_apt() {
+    local pkg="$1"
+    dpkg -l 2>/dev/null | grep -q "^ii  $pkg "
+}
+
+is_installed_pacman() {
+    local pkg="$1"
+    pacman -Q "$pkg" >/dev/null 2>&1
+}
+
 install_apt() {
     local pkg="$1"
     local name="${2:-$pkg}"
-    
-    if dpkg -l 2>/dev/null | grep -q "^ii  $pkg "; then
-        log_success "$name already installed"
-        return 0
-    fi
-    
-    log_step "Installing $name..."
-    if [[ "$DRY_RUN" == "true" ]]; then
-        echo -e "\033[0;36m[DRY RUN]\033[0m Would run: sudo apt install -y $pkg"
-    else
-        sudo apt install -y -qq "$pkg" 2>&1 | grep -v "^Reading" | grep -v "^Building" | grep -v "^0 upgraded" | grep -v "already the newest" | grep -v "set to manually" | grep -v "no longer required" | grep -v "autoremove" | grep -v "WARNING" | grep -v "nvidia-firmware" | grep -v "ocl-icd" || true
-    fi
-    log_success "$name installed"
+    local package_manager
+    package_manager="$(detect_package_manager)"
+
+    case "$package_manager" in
+        apt)
+            if is_installed_apt "$pkg"; then
+                log_success "$name already installed"
+                return 0
+            fi
+
+            log_step "Installing $name..."
+            if [[ "$DRY_RUN" == "true" ]]; then
+                echo -e "\033[0;36m[DRY RUN]\033[0m Would run: sudo apt install -y $pkg"
+            else
+                sudo apt install -y -qq "$pkg" 2>&1 | grep -v "^Reading" | grep -v "^Building" | grep -v "^0 upgraded" | grep -v "already the newest" | grep -v "set to manually" | grep -v "no longer required" | grep -v "autoremove" | grep -v "WARNING" | grep -v "nvidia-firmware" | grep -v "ocl-icd" || true
+            fi
+            log_success "$name installed"
+            ;;
+        pacman)
+            local mapped_pkg
+            mapped_pkg="$(map_pacman_package_name "$pkg")"
+
+            if [[ "$mapped_pkg" == "__skip__" ]]; then
+                log_info "Skipping $name on pacman-based systems"
+                return 0
+            fi
+
+            if is_installed_pacman "$mapped_pkg"; then
+                log_success "$name already installed"
+                return 0
+            fi
+
+            log_step "Installing $name..."
+            if [[ "$DRY_RUN" == "true" ]]; then
+                echo -e "\033[0;36m[DRY RUN]\033[0m Would run: sudo pacman -S --noconfirm --needed $mapped_pkg"
+            else
+                sudo pacman -S --noconfirm --needed "$mapped_pkg" >/dev/null 2>&1 || log_warn "Failed to install $name ($mapped_pkg) via pacman"
+            fi
+            log_success "$name installed"
+            ;;
+        *)
+            log_error "No supported package manager found (apt/pacman)"
+            return 1
+            ;;
+    esac
 }
 
 install_snap() {

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -138,10 +138,14 @@ configure_icons() {
     if fc-list | grep -qi "Papirus"; then
         log_success "Papirus icons already installed"
     else
-        sudo rm -f /etc/apt/sources.list.d/thopiekar* 2>/dev/null || true
-        sudo add-apt-repository -y ppa:papirus/papirus 2>&1 | grep -v "^Hit:" | grep -v "^Get:" | grep -v "^Ign:" | grep -v "^Reading" || true
-        sudo apt update -qq 2>&1 | grep -v "^Hit:" | grep -v "^Get:" | grep -v "^Reading" || true
-        sudo apt install -y -qq papirus-icon-theme 2>&1 | grep -v "^Selecting" | grep -v "^Preparing" | grep -v "^Unpacking" | grep -v "^Setting up" || true
+        if command -v apt >/dev/null 2>&1; then
+            sudo rm -f /etc/apt/sources.list.d/thopiekar* 2>/dev/null || true
+            sudo add-apt-repository -y ppa:papirus/papirus 2>&1 | grep -v "^Hit:" | grep -v "^Get:" | grep -v "^Ign:" | grep -v "^Reading" || true
+            sudo apt update -qq 2>&1 | grep -v "^Hit:" | grep -v "^Get:" | grep -v "^Reading" || true
+            sudo apt install -y -qq papirus-icon-theme 2>&1 | grep -v "^Selecting" | grep -v "^Preparing" | grep -v "^Unpacking" | grep -v "^Setting up" || true
+        elif command -v pacman >/dev/null 2>&1; then
+            sudo pacman -S --noconfirm --needed papirus-icon-theme >/dev/null 2>&1 || true
+        fi
     fi
     gsettings set org.gnome.desktop.interface icon-theme 'Papirus-Dark' 2>/dev/null || true
     log_success "Icon theme configured"


### PR DESCRIPTION
### Motivation

- Extend the setup installer to support Arch-based systems using `pacman` in addition to Debian/Ubuntu `apt`.
- Ensure icon/theme installation and package mapping work correctly across different package managers.

### Description

- Introduce `detect_package_manager()` to choose between `apt`, `pacman`, or `unknown` and expose it to installer functions.
- Add `map_pacman_package_name()` to translate common Debian package names to their `pacman` equivalents and skip unsupported mappings.
- Add `is_installed_pacman()` and `is_installed_apt()` checks and update `install_apt()` to handle both `apt` and `pacman` code paths, including dry-run output and package install logging.
- Update `setup/setup.sh` `configure_icons()` to use `pacman` when available instead of only running `apt` commands for Papirus installation.
- Update `README.md` to note that the setup script supports both `apt` and `pacman` package managers.

### Testing

- Ran a smoke test with the installer in dry-run mode using `./setup/setup.sh --dry-run` to exercise package manager branches, which completed without runtime errors.
- Ran `shellcheck` against `setup/lib/installers.sh` as a quick lint pass and addressed notable issues (no blocking warnings remained).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6b518480c832690241989af24d510)

## Summary by Sourcery

Add cross-distro package manager support and improve icon installation behavior.

New Features:
- Add package manager detection to support both apt and pacman in installer workflows.
- Add package name mapping and installation checks to handle Arch-based package names alongside Debian ones.

Enhancements:
- Update Papirus icon installation to use pacman on Arch-based systems when available, falling back to apt on Debian-based systems.
- Improve installer dry-run and logging behavior for package installations across supported package managers.

Documentation:
- Document that the setup script supports both apt (Debian/Ubuntu) and pacman (Arch-based) package managers in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup script now supports Arch-based Linux systems (using pacman) alongside Debian/Ubuntu systems (using apt).

* **Documentation**
  * Updated README to clarify multi-distro package manager support for the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->